### PR TITLE
Add the EventEmitter.addListener function to resolve a compatibility problem with the continuation-local-storage module

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ function Mitm() {
 Mitm.prototype.on = EventEmitter.prototype.on
 Mitm.prototype.once = EventEmitter.prototype.once
 Mitm.prototype.off = EventEmitter.prototype.removeListener
+Mitm.prototype.addListener = EventEmitter.prototype.addListener
 Mitm.prototype.removeListener = EventEmitter.prototype.removeListener
 Mitm.prototype.emit = EventEmitter.prototype.emit
 

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -448,6 +448,12 @@ describe("Mitm", function() {
     })
   })
 
+  describe(".prototype.addListener", function() {
+    it("must be an alias to EventEmitter.prototype.addListener", function() {
+      Mitm.prototype.addListener.must.equal(EventEmitter.prototype.addListener)
+    })
+  })
+
   describe(".prototype.off", function() {
     it("must be an alias to EventEmitter.prototype.removeListener", function() {
       Mitm.prototype.off.must.equal(EventEmitter.prototype.removeListener)


### PR DESCRIPTION
The [continuation-local-storage](https://github.com/othiym23/node-continuation-local-storage) module includes a function to bind an EventEmitter to a continuation-local namespace. 

Before binding, the EventEmitter is [checked for a minimum number of required functions](https://github.com/othiym23/node-continuation-local-storage/blob/0099561d2bd0b17a8621e8fe8ac637c94f0e628d/context.js#L113). Among them is the `addListener()` function. 

Because the mitm module does not implement the `addListener()` function, it is incompatible with the continuation-local-storage module.

This PR makes the `addListener()` function available so that it can be wrapped by the contination-local-storage `bindEmitter()` function.
