### PR TITLE
fix: make mitm work on iojs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-node_js: ["0.10", "0.11", "0.12"]
+node_js: ["0.10", "0.11", "0.12", "iojs"]
 
 notifications:
   email: ["andri@dot.ee"]

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -10,3 +10,8 @@ Socket.prototype = Object.create(Net.Socket.prototype, {
 Socket.prototype.bypass = function() {
   this.bypassed = true
 }
+
+// iojs ssl implementation needs this,
+// see https://github.com/moll/node-mitm/pull/23
+// WHY? I dunno. You do? Contact us!
+Socket.prototype.getSession = function() {}


### PR DESCRIPTION
some of my libraries were not working in iojs. showing 

```
TypeError: this._handle.getSession is not a function
    at TlsSocket.TLSSocket.getSession (_tls_wrap.js:609:25)
    at TlsSocket.<anonymous> (https.js:77:50)
    at TlsSocket.g (events.js:260:16)
    at emitNone (events.js:67:13)
    at TlsSocket.emit (events.js:166:7)
    at doNTCallback0 (node.js:407:9)
    at process._tickCallback (node.js:336:13)
```

So let's add this function.

![xvyosl](https://cloud.githubusercontent.com/assets/123822/9581547/66669214-5000-11e5-93b1-7b65b3216658.jpg)
