### PR TITLE
Delay 'connect' events by an extra tick

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,10 +83,13 @@ function connect(orig, Socket, opts, done) {
   var server = client.server = new Socket({handle: sockets[1]})
   this.emit("connection", server, opts)
 
-  // Emit connect in the next tick, otherwise it would be impossible to
-  // listen to it after calling Net.connect.
-  process.nextTick(client.emit.bind(client, "connect"))
-  process.nextTick(server.emit.bind(server, "connect"))
+  // emit('socket') happens in the next tick, so we need to delay the 'connect' event on the socket with two ticks
+  process.nextTick(function () {
+    // Emit connect in the next tick, otherwise it would be impossible to
+    // listen to it after calling Net.connect.
+    process.nextTick(client.emit.bind(client, "connect"))
+    process.nextTick(server.emit.bind(server, "connect"))
+  })
 
   return client
 }

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -70,26 +70,42 @@ describe("Mitm", function() {
         onConnection.firstCall.args[1].must.equal(opts)
       })
 
-      it("must emit connect on socket in next tick", function(done) {
+      it("must emit connect on socket in two ticks", function(done) {
         var socket = module.connect({host: "foo"})
         var onConnect = Sinon.spy()
         socket.on("connect", onConnect)
-        process.nextTick(function() { onConnect.callCount.must.equal(1) })
-        process.nextTick(done)
+        process.nextTick(function() {
+          onConnect.callCount.must.equal(0)
+          process.nextTick(function() {
+            onConnect.callCount.must.equal(1)
+            done()
+          })
+        })
       })
 
       it("must call back on connect given callback", function(done) {
         var onConnect = Sinon.spy()
         module.connect({host: "foo"}, onConnect)
-        process.nextTick(function() { onConnect.callCount.must.equal(1) })
-        process.nextTick(done)
+        process.nextTick(function() {
+          onConnect.callCount.must.equal(0)
+          process.nextTick(function() {
+            onConnect.callCount.must.equal(1)
+            done()
+          })
+        })
       })
 
       it("must call back on connect given port and callback", function(done) {
         var onConnect = Sinon.spy()
         module.connect(80, onConnect)
-        process.nextTick(function() { onConnect.callCount.must.equal(1) })
-        process.nextTick(done)
+
+        process.nextTick(function() {
+          onConnect.callCount.must.equal(0)
+          process.nextTick(function() {
+            onConnect.callCount.must.equal(1)
+            done()
+          })
+        })
       })
 
       // This was a bug found on Apr 26, 2014 where the host argument was taken
@@ -99,8 +115,14 @@ describe("Mitm", function() {
         function(done) {
         var onConnect = Sinon.spy()
         module.connect(80, "localhost", onConnect)
-        process.nextTick(function() { onConnect.callCount.must.equal(1) })
-        process.nextTick(done)
+
+        process.nextTick(function() {
+          onConnect.callCount.must.equal(0)
+          process.nextTick(function() {
+            onConnect.callCount.must.equal(1)
+            done()
+          })
+        })
       })
 
       it("must intercept 127.0.0.1", function() {


### PR DESCRIPTION
I was unable to mock out http using mitm for the stripe-node repository: https://github.com/stripe/stripe-node/blob/master/lib/StripeResource.js#L238

The 'socket' event is fired after the 'connect' event on the socket, which caused that code to fail.
As the 'socket' event on req happens in the next tick, the 'connect' event on the socket needs to be delayed by an extra tick, which is what this pull request achieves.