### PR TITLE
Expose connect options and the client socket via a _mitm property

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,6 +79,11 @@ Mitm.prototype.connect = function connect(orig, Socket, opts, done) {
   var server = client.server = new Socket({handle: sockets[1]})
   this.emit("connection", server, opts)
 
+  // Make the client socket and the connect options available via a "private"
+  // property of the server socket so they can be paired up with requests in
+  // a reliable way:
+  server._mitm = {client: client, opts: opts};
+
   // Ensure connect is emitted in next ticks, otherwise it would be impossible
   // to listen to it after calling Net.connect or listening to it after the
   // ClientRequest emits "socket".

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -442,6 +442,25 @@ describe("Mitm", function() {
         })
       })
 
+      it("must provide the client socket and options via _mitm", function(done) {
+        var clientSocket;
+        var connectOpts;
+        this.mitm.on("connect", function (socket, opts) {
+          clientSocket = socket
+          connectOpts = opts
+          clientSocket.must.be.an.instanceof(Object)
+          connectOpts.host.must.equal("foo")
+        }).on("request", function(req, res) {
+          req.connection._mitm.must.be.an.instanceof(Object)
+          req.connection._mitm.opts.must.be(connectOpts)
+          req.connection._mitm.client.must.be(clientSocket)
+          done()
+        })
+
+        var client = request({host: "foo"})
+        client.end()
+      })
+
       it("must emit request on Mitm after multiple requests", function(done) {
         request({host: "foo"}).end()
         request({host: "foo"}).end()


### PR DESCRIPTION
Fixes #14.

I ran into a scenario where it was impossible to pair up client sockets, connect options, and HTTP requests using the current API.

This (or something similar) makes it possible to avoid the guesswork and actually simplify my code a bit: https://github.com/unexpectedjs/unexpected-mitm/pull/19/files
