### PR TITLE
Implement InternalSocket.prototype.writeLatin1String

### DIFF
--- a/lib/internal_socket.js
+++ b/lib/internal_socket.js
@@ -75,6 +75,10 @@ InternalSocket.prototype.writeBinaryString = function(req, data) {
   this.write(data, "binary")
 }
 
+InternalSocket.prototype.writeLatin1String = function(req, data) {
+  this.write(data, "latin1")
+}
+
 InternalSocket.prototype.writeBuffer = function(req, data) {
   this.write(NODE_0_10 ? req : data)
   if (NODE_0_10) return {}


### PR DESCRIPTION
Prevent failure with node.js 6.4.0 due to
https://github.com/nodejs/node/commit/28071a130e2137bd14d0762a25f0ad83b7a28259

The error I ran into looked like this: https://travis-ci.org/assetgraph/assetgraph/jobs/152717292#L357-L372