### PR TITLE
fix(node v6): ref and unref are expected on sockets

### DIFF
--- a/lib/internal_socket.js
+++ b/lib/internal_socket.js
@@ -70,6 +70,10 @@ InternalSocket.prototype._write = function(data, encoding, done) {
 // a "oncomplete" and "cb" property. Node v0.11 expects it return an error
 // instead.
 
+// those two ones are expected in 0.10
+InternalSocket.prototype.unref = function() {}
+InternalSocket.prototype.ref = function() {}
+
 // InternalSocket.prototype.writeBinaryString was introduced in Node v0.11.14.
 InternalSocket.prototype.writeBinaryString = function(req, data) {
   this.write(data, "binary")


### PR DESCRIPTION
Node.js current code does reference ref and unref, my tests are failing on node 6.5.0 using latest node-mitm. Possibly because of using ssl sockets somewhere.

This completely fix it, no idea how to create a test though