### PR TITLE
Fix for node v7

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ var EventEmitter = require("events").EventEmitter
 var InternalSocket = require("./lib/internal_socket")
 var Stubs = require("./lib/stubs")
 var slice = Function.call.bind(Array.prototype.slice)
-var normalizeConnectArgs = Net._normalizeConnectArgs
+var normalizeConnectArgs = Net._normalizeConnectArgs || Net._normalizeArgs
 var createRequestAndResponse = Http._connectionListener
 module.exports = Mitm
 


### PR DESCRIPTION
`_normalizeConnectArgs` was changed to `_normalizeArgs` in Node v7.