### PR TITLE
Wire up internals for node.js 9.6.0+ compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,8 +43,10 @@ if (NODE_GTE_9_6_0) {
   var _httpIncoming = require('_http_incoming')
   var kIncomingMessage = require('_http_common').kIncomingMessage
 
-  Socket.prototype[kIncomingMessage] = Mitm.prototype[kIncomingMessage] =
-    _httpIncoming.IncomingMessage
+  TlsSocket.prototype[kIncomingMessage] =
+    Socket.prototype[kIncomingMessage] =
+    Mitm.prototype[kIncomingMessage] =
+      _httpIncoming.IncomingMessage
 
   Mitm.prototype[_httpServer.kServerResponse] = _httpServer.ServerResponse
 }

--- a/index.js
+++ b/index.js
@@ -38,6 +38,17 @@ var NODE_0_10 = versionDigits[0] === 0 && versionDigits[1] === 10
 var NODE_GTE_9_6_0 =
   (versionDigits[0] === 9 && versionDigits[1] >= 6) || versionDigits[0] > 9
 
+if (NODE_GTE_9_6_0) {
+  var _httpServer = require('_http_server')
+  var _httpIncoming = require('_http_incoming')
+  var kIncomingMessage = require('_http_common').kIncomingMessage
+
+  Socket.prototype[kIncomingMessage] = Mitm.prototype[kIncomingMessage] =
+    _httpIncoming.IncomingMessage
+
+  Mitm.prototype[_httpServer.kServerResponse] = _httpServer.ServerResponse
+}
+
 Mitm.prototype.enable = function() {
   // Connect is called synchronously.
   var netConnect = this.tcpConnect.bind(this, Net.connect)
@@ -82,16 +93,6 @@ Mitm.prototype.connect = function connect(orig, Socket, opts, done) {
   if (client.bypassed) return orig.call(this, opts, done)
 
   var server = client.server = new Socket({handle: sockets[1]})
-
-  if (NODE_GTE_9_6_0) {
-    var _httpServer = require('_http_server')
-    var _httpIncoming = require('_http_incoming')
-    var kIncomingMessage = require('_http_common').kIncomingMessage
-    server[kIncomingMessage] = this[kIncomingMessage] =
-      _httpIncoming.IncomingMessage
-
-    this[_httpServer.kServerResponse] = _httpServer.ServerResponse
-  }
 
   this.emit("connection", server, opts)
 

--- a/index.js
+++ b/index.js
@@ -31,7 +31,12 @@ Mitm.prototype.addListener = EventEmitter.prototype.addListener
 Mitm.prototype.removeListener = EventEmitter.prototype.removeListener
 Mitm.prototype.emit = EventEmitter.prototype.emit
 
-var NODE_0_10 = !!process.version.match(/^v0\.10\./)
+var versionDigits = process.version.replace(/^v/, '').split('.').map(function(str) {
+  return parseInt(str, 10);
+})
+var NODE_0_10 = versionDigits[0] === 0 && versionDigits[1] === 10
+var NODE_GTE_9_6_0 =
+  (versionDigits[0] === 9 && versionDigits[1] >= 6) || versionDigits[0] > 9
 
 Mitm.prototype.enable = function() {
   // Connect is called synchronously.
@@ -77,6 +82,17 @@ Mitm.prototype.connect = function connect(orig, Socket, opts, done) {
   if (client.bypassed) return orig.call(this, opts, done)
 
   var server = client.server = new Socket({handle: sockets[1]})
+
+  if (NODE_GTE_9_6_0) {
+    var _httpServer = require('_http_server')
+    var _httpIncoming = require('_http_incoming')
+    var kIncomingMessage = require('_http_common').kIncomingMessage
+    server[kIncomingMessage] = this[kIncomingMessage] =
+      _httpIncoming.IncomingMessage
+
+    this[_httpServer.kServerResponse] = _httpServer.ServerResponse
+  }
+
   this.emit("connection", server, opts)
 
   // Ensure connect is emitted in next ticks, otherwise it would be impossible

--- a/index.js
+++ b/index.js
@@ -95,7 +95,6 @@ Mitm.prototype.connect = function connect(orig, Socket, opts, done) {
   if (client.bypassed) return orig.call(this, opts, done)
 
   var server = client.server = new Socket({handle: sockets[1]})
-
   this.emit("connection", server, opts)
 
   // Ensure connect is emitted in next ticks, otherwise it would be impossible


### PR DESCRIPTION
Fixes #48 

This feels quite hackish, but I couldn't find another way to make it work except for PRing node.js core. It kinda feels like this line should also have checked for `parser.socket.server[kIncomingMessage]`: https://github.com/nodejs/node/blob/15e41a9951c425913c43073ba5f6af04c0867715/lib/_http_common.js#L78 -- but even that would only get us halfway there.