### PR TITLE
FIX underscore CVE-2021-23358

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 	"scripts": {"test": "make test"},
 
 	"dependencies": {
-		"underscore": ">= 1.1.6 < 1.6",
+		"underscore": ">= 1.1.6 < 1.14",
 		"semver": ">= 5 < 6"
 	},
 


### PR DESCRIPTION
The package underscore from 1.13.0-0 and before 1.13.0-2, from 1.3.2 and before 1.12.1 are vulnerable to Arbitrary Code Injection via the template function, particularly when a variable property is passed as an argument as it is not sanitized